### PR TITLE
add `withRequestTimeout(...)` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Configure your authorization server to allow `http://127.0.0.1/*` as a redirect 
 // this library will just perform the Authorization Flow:
 var httpResponse = TinyOAuth2.client("oauth-client-id")
 		.withTokenEndpoint(URI.create("https://login.example.com/oauth2/token"))
+        .withRequestTimeout(Duration.ofSeconds(10)) // optional
 		.authFlow(URI.create("https://login.example.com/oauth2/authorize"))
 		.authorize(uri -> System.out.println("Please login on " + uri));
 

--- a/src/main/java/io/github/coffeelibs/tinyoauth2client/TinyOAuth2Client.java
+++ b/src/main/java/io/github/coffeelibs/tinyoauth2client/TinyOAuth2Client.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -21,6 +22,8 @@ import java.util.concurrent.Executor;
 @ApiStatus.Experimental
 public class TinyOAuth2Client {
 
+    private static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
     /**
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-2.2">Client Identifier</a>
      */
@@ -31,9 +34,29 @@ public class TinyOAuth2Client {
      */
     final URI tokenEndpoint;
 
+    /**
+     * Timeout of HTTP requests
+     */
+    final Duration requestTimeout;
+
     TinyOAuth2Client(String clientId, URI tokenEndpoint) {
+        this(clientId, tokenEndpoint, DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    private TinyOAuth2Client(String clientId, URI tokenEndpoint, Duration requestTimeout) {
         this.clientId = Objects.requireNonNull(clientId);
         this.tokenEndpoint = Objects.requireNonNull(tokenEndpoint);
+        this.requestTimeout = Objects.requireNonNull(requestTimeout);
+    }
+
+    /**
+     * Creates a new OAuth2 Client with the specified request timeout
+     * @param requestTimeout HTTP request timeout
+     * @return A new client
+     * @since 0.7.0
+     */
+    public TinyOAuth2Client withRequestTimeout(Duration requestTimeout) {
+        return new TinyOAuth2Client(this.clientId, this.tokenEndpoint, requestTimeout);
     }
 
     /**
@@ -130,6 +153,7 @@ public class TinyOAuth2Client {
         return HttpRequest.newBuilder(tokenEndpoint) //
                 .header("Content-Type", "application/x-www-form-urlencoded") //
                 .POST(HttpRequest.BodyPublishers.ofString(urlencodedParams)) //
+                .timeout(requestTimeout) //
                 .build();
     }
 

--- a/src/test/java/io/github/coffeelibs/tinyoauth2client/TinyOAuth2ClientTest.java
+++ b/src/test/java/io/github/coffeelibs/tinyoauth2client/TinyOAuth2ClientTest.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -29,6 +30,18 @@ public class TinyOAuth2ClientTest {
         Assertions.assertSame(authFlow.client, client);
         Assertions.assertSame(authFlow.authEndpoint, authEndpoint);
         Assertions.assertNotNull(authFlow.pkce);
+    }
+
+    @Test
+    @DisplayName("withRequestTimeout(...)")
+    public void testWithRequestTimeout() {
+        var client = new TinyOAuth2Client("my-client", URI.create("http://example.com/oauth2/token"));
+        var timeout = Duration.ofMillis(1337L);
+
+        var newClient = client.withRequestTimeout(timeout);
+
+        Assertions.assertNotSame(client, newClient);
+        Assertions.assertEquals(timeout, newClient.requestTimeout);
     }
 
     @Test
@@ -181,6 +194,7 @@ public class TinyOAuth2ClientTest {
             bodyPublishersClass.verify(() -> HttpRequest.BodyPublishers.ofString("query=string&mock=true"));
             Assertions.assertEquals(tokenEndpoint, request.uri());
             Assertions.assertEquals("POST", request.method());
+            Assertions.assertEquals(client.requestTimeout, request.timeout().get());
             Assertions.assertEquals(bodyPublisher, request.bodyPublisher().get());
             Assertions.assertEquals("application/x-www-form-urlencoded", request.headers().firstValue("Content-Type").orElse(null));
         }


### PR DESCRIPTION
Allows setting the timeout of token requests.

This does not add a timeout to the timespan between start of the Auth Flow and its fulfillment (i.e. redirecting back to the app). 