### PR TITLE
Consolidate API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,40 +17,48 @@ support for [PKCE](https://datatracker.ietf.org/doc/html/rfc8252#section-8.1) an
 
 ## Usage
 
-Configure your authorization server to allow `http://127.0.0.1/*` as a redirect target and look up these configuration values:
+You begin building an OAuth 2.0 Client via the fluent API:
 
-* client identifier
-* token endpoint
-* authorization endpoint
+```java
+var oauthClient = TinyOAuth2.client("oauth-client-id") // The client identifier
+		.withTokenEndpoint(URI.create("https://login.example.com/oauth2/token")) // The token endpoint
+		.withRequestTimeout(Duration.ofSeconds(10)) // optional
+        // ...
+```
+
+Next, continue with a specific grant type by invoking `.authorizationCodeGrant(...)` or `.clientCredentialsGrant(...)` (more may be added eventually).
+
+This library requires you to provide an instance of [`java.net.http.HttpClient`](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html).
+This allows you to configure it to your needs, e.g. by applying proxy settings:
+
+```java
+var httpClient = HttpClient.newBuilder()
+    .proxy(ProxySelector.of(InetSocketAddress.createUnresolved("https:\\example.com",1337)))
+    .build();
+```
+
+### Authorization Code Grant
+Usually, you would want to use the [Authorization Code Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) type to obtain access tokens.
+Configure your Authorization Server to allow `http://127.0.0.1/*` as a redirect target and look up the authorization endpoint:
 
 ```java
 // this library will just perform the Authorization Flow:
-var httpResponse = TinyOAuth2.client("oauth-client-id")
-		.withTokenEndpoint(URI.create("https://login.example.com/oauth2/token"))
-		.withRequestTimeout(Duration.ofSeconds(10)) // optional
-		.authorizationCodeGrant(URI.create("https://login.example.com/oauth2/authorize"))
-		.authorize(uri -> System.out.println("Please login on " + uri));
-
-// from this point onwards, please proceed with the JSON/JWT parser of your choice:
-if (httpResponse.statusCode() == 200) {
-	var jsonString = httpResponse.body()
-	var bearerToken = parseJson(jsonString).get("access_token");
-	// ...
-}
-```
-
-If you wish to use a proxy or your own set of root certificates, provide your own JDK [http client](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html):
-```java
-var httpClient = HttpClient.newBuilder()
-        .proxy(ProxySelector.of(InetSocketAddress.createUnresolved("https:\\example.com",1337)))
-        .build();
-var httpResponse = TinyOAuth2.client("oauth-client-id")
-		.withTokenEndpoint(URI.create("https://login.example.com/oauth2/token"))
-		.authorizationCodeGrant(URI.create("https://login.example.com/oauth2/authorize"))
+var httpResponse = oauthClient.authorizationCodeGrant(URI.create("https://login.example.com/oauth2/authorize"))
 		.authorize(httpClient, uri -> System.out.println("Please login on " + uri));
 ```
 
-If your authorization server doesn't allow wildcards, you can also configure a fixed path (and even port) via e.g. `setRedirectPath("/callback")` and `setRedirectPorts(8080)`.
+If your authorization server doesn't allow wildcards, you can also configure a fixed path (and even port) via e.g. `setRedirectPath("/callback")` and `setRedirectPorts(8080)` before calling `authorize(...)`.
+
+### Parsing the Response
+For maximum flexibility and minimal attack surface, this library does not include or depend on a specific parser. Instead, use a JSON or JWT parser of your choice to parse the Authorization Server's response:
+
+```java
+if (httpResponse.statusCode() == 200) {
+		var jsonString = httpResponse.body()
+		var bearerToken = parseJson(jsonString).get("access_token");
+		// ...
+}
+```
 
 ## Why this library?
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,19 @@ support for [PKCE](https://datatracker.ietf.org/doc/html/rfc8252#section-8.1) an
 
 ## Usage
 
-You begin building an OAuth 2.0 Client via the fluent API:
+This library requires an instance of [`java.net.http.HttpClient`](https://docs.oracle.com/en/java/javase/21/docs/api/java.net.http/java/net/http/HttpClient.html).
+
+```java
+// usually the default is sufficent:
+var httpClient = HttpClient.newHttpClient();
+
+// but feel free to adjust it to your needs, e.g. by applying custom proxy settings:
+var httpClient = HttpClient.newBuilder()
+    .proxy(ProxySelector.of(InetSocketAddress.createUnresolved("https:\\example.com",1337)))
+    .build();
+```
+
+Now to begin, start building an OAuth 2.0 Client via the fluent API:
 
 ```java
 var oauthClient = TinyOAuth2.client("oauth-client-id") // The client identifier
@@ -27,15 +39,6 @@ var oauthClient = TinyOAuth2.client("oauth-client-id") // The client identifier
 ```
 
 Next, continue with a specific grant type by invoking `.authorizationCodeGrant(...)` or `.clientCredentialsGrant(...)` (more may be added eventually).
-
-This library requires you to provide an instance of [`java.net.http.HttpClient`](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html).
-This allows you to configure it to your needs, e.g. by applying proxy settings:
-
-```java
-var httpClient = HttpClient.newBuilder()
-    .proxy(ProxySelector.of(InetSocketAddress.createUnresolved("https:\\example.com",1337)))
-    .build();
-```
 
 ### Authorization Code Grant
 Usually, you would want to use the [Authorization Code Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) type to obtain access tokens.

--- a/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java
+++ b/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java
@@ -7,6 +7,7 @@ import io.github.coffeelibs.tinyoauth2client.util.URIUtil;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NonBlocking;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.IOException;
@@ -119,13 +120,12 @@ public class AuthorizationCodeGrant {
     }
 
     /**
-     * Asks the given {@code browser} to browse the authorization URI. This method will block until the browser is
-     * <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-4.1">redirected back to this application</a>.
+     * Asks the given {@code browser} to browse the authorization URI. As soon as the browser is
+     * <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-4.1">redirected back to this application</a>, the
+     * received authorization code is used to make an <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3">Access Token Request</a>.
      * <p>
-     * Then, the received authorization code is used to make an
-     * <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3">Access Token Request</a>.
-     * <p>
-     * The executor used to the request the auth code and get the access token is the same specified in {@link HttpClient.Builder#executor(Executor)}. If the given http client does not provide an executor via {@link HttpClient#executor()}, a default single thread executor is used for requesting the authorization code.
+     * The executor used to the request the auth code and get the access token is the same specified in {@link HttpClient.Builder#executor(Executor)}.
+     * If the given http client does not provide an executor via {@link HttpClient#executor()}, a default single thread executor is used for requesting the authorization code.
      *
      * @param httpClient The http client used for the access token request
      * @param browser    An async callback (not blocking the executor) that opens a web browser with the URI it consumes
@@ -133,14 +133,16 @@ public class AuthorizationCodeGrant {
      * @return The future <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4">Access Token Response</a>
      * @see #authorize(HttpClient, Consumer, String...)
      */
+    @NonBlocking
     public CompletableFuture<HttpResponse<String>> authorizeAsync(HttpClient httpClient, Consumer<URI> browser, String... scopes) {
+        Executor executor = httpClient.executor().orElse(ForkJoinPool.commonPool());
         return CompletableFuture.supplyAsync(() -> {
             try {
                 return requestAuthCode(browser, scopes);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-        }, httpClient.executor().orElse(ForkJoinPool.commonPool())).thenCompose(authorizedGrant -> authorizedGrant.getAccessTokenAsync(httpClient));
+        }, executor).thenCompose(authorizedGrant -> authorizedGrant.getAccessTokenAsync(httpClient));
     }
 
     /**
@@ -240,7 +242,7 @@ public class AuthorizationCodeGrant {
         public HttpResponse<String> getAccessToken(HttpClient httpClient) throws IOException, InterruptedException {
             // see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
             // and https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4
-            return httpClient.send(buildTokenRequest(), HttpResponse.BodyHandlers.ofString()); //TODO
+            return httpClient.send(buildTokenRequest(), HttpResponse.BodyHandlers.ofString());
         }
     }
 }

--- a/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java
+++ b/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java
@@ -124,8 +124,8 @@ public class AuthorizationCodeGrant {
      * <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-4.1">redirected back to this application</a>, the
      * received authorization code is used to make an <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3">Access Token Request</a>.
      * <p>
-     * The executor used to the request the auth code and get the access token is the same specified in {@link HttpClient.Builder#executor(Executor)}.
-     * If the given http client does not provide an executor via {@link HttpClient#executor()}, a default single thread executor is used for requesting the authorization code.
+     * The callback to open the web browser will be executed asynchronously, facilitating the {@link HttpClient#executor() HttpClient's executor}
+     * (if an executor {@link HttpClient.Builder#executor(Executor) has been specified}).
      *
      * @param httpClient The http client used for the access token request
      * @param browser    An async callback (not blocking the executor) that opens a web browser with the URI it consumes

--- a/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java
+++ b/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java
@@ -4,7 +4,10 @@ import io.github.coffeelibs.tinyoauth2client.http.RedirectTarget;
 import io.github.coffeelibs.tinyoauth2client.http.response.Response;
 import io.github.coffeelibs.tinyoauth2client.util.RandomUtil;
 import io.github.coffeelibs.tinyoauth2client.util.URIUtil;
-import org.jetbrains.annotations.*;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Blocking;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java
+++ b/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java
@@ -121,23 +121,6 @@ public class AuthorizationCodeGrant {
      * <p>
      * Then, the received authorization code is used to make an
      * <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3">Access Token Request</a>.
-     *
-     * @param executor The executor to run the async tasks
-     * @param browser  An async callback (not blocking the executor) that opens a web browser with the URI it consumes
-     * @param scopes   The desired <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">scopes</a>
-     * @return The future <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4">Access Token Response</a>
-     * @see #authorize(Consumer, String...)
-     */
-    public CompletableFuture<HttpResponse<String>> authorizeAsync(@BlockingExecutor Executor executor, Consumer<URI> browser, String... scopes) {
-        return authorizeAsync(HttpClient.newBuilder().executor(executor).build(), browser, scopes);
-    }
-
-    /**
-     * Asks the given {@code browser} to browse the authorization URI. This method will block until the browser is
-     * <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-4.1">redirected back to this application</a>.
-     * <p>
-     * Then, the received authorization code is used to make an
-     * <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3">Access Token Request</a>.
      * <p>
      * The executor used to the request the auth code and get the access token is the same specified in {@link HttpClient.Builder#executor(Executor)}. If the given http client does not provide an executor via {@link HttpClient#executor()}, a default single thread executor is used for requesting the authorization code.
      *
@@ -145,7 +128,7 @@ public class AuthorizationCodeGrant {
      * @param browser    An async callback (not blocking the executor) that opens a web browser with the URI it consumes
      * @param scopes     The desired <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">scopes</a>
      * @return The future <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4">Access Token Response</a>
-     * @see #authorize(Consumer, String...)
+     * @see #authorize(HttpClient, Consumer, String...)
      */
     public CompletableFuture<HttpResponse<String>> authorizeAsync(HttpClient httpClient, Consumer<URI> browser, String... scopes) {
         return CompletableFuture.supplyAsync(() -> {
@@ -164,32 +147,13 @@ public class AuthorizationCodeGrant {
      * Then, the received authorization code is used to make an
      * <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3">Access Token Request</a>.
      *
-     * @param browser An async callback (not blocking this thread) that opens a web browser with the URI it consumes
-     * @param scopes  The desired <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">scopes</a>
-     * @return The <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4">Access Token Response</a>
-     * @throws IOException          In case of I/O errors when communicating with the token endpoint
-     * @throws InterruptedException When this thread is interrupted before a response is received
-     * @see #authorizeAsync(Executor, Consumer, String...)
-     */
-    @Blocking
-    public HttpResponse<String> authorize(Consumer<URI> browser, String... scopes) throws IOException, InterruptedException {
-        return authorize(HttpClient.newHttpClient(), browser, scopes);
-    }
-
-    /**
-     * Asks the given {@code browser} to browse the authorization URI. This method will block until the browser is
-     * <a href="https://datatracker.ietf.org/doc/html/rfc8252#section-4.1">redirected back to this application</a>.
-     * <p>
-     * Then, the received authorization code is used to make an
-     * <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3">Access Token Request</a>.
-     *
      * @param httpClient The http client used to recieve the authorization code
      * @param browser    An async callback (not blocking this thread) that opens a web browser with the URI it consumes
      * @param scopes     The desired <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">scopes</a>
      * @return The <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.4">Access Token Response</a>
      * @throws IOException          In case of I/O errors when communicating with the token endpoint
      * @throws InterruptedException When this thread is interrupted before a response is received
-     * @see #authorizeAsync(Executor, Consumer, String...)
+     * @see #authorizeAsync(HttpClient, Consumer, String...)
      */
     @Blocking
     public HttpResponse<String> authorize(HttpClient httpClient, Consumer<URI> browser, String... scopes) throws IOException, InterruptedException {

--- a/src/test/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrantTest.java
+++ b/src/test/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrantTest.java
@@ -341,31 +341,17 @@ public class AuthorizationCodeGrantTest {
         Assertions.assertEquals(httpResponse, result.get());
     }
 
-
-    @Test
-    @DisplayName("authorizeAsync(executor, ...) delegates to authorizeAsync(httpClient,...) with executor set in httpClient")
-    @SuppressWarnings("unchecked")
-    public void testAuthorizeAsync2() {
-        var executor = Mockito.mock(Executor.class);
-        Consumer<URI> browser = Mockito.mock(Consumer.class);
-        var grant = Mockito.spy(new AuthorizationCodeGrant(client, authEndpoint, pkce));
-
-        grant.authorizeAsync(executor, browser);
-        ArgumentCaptor<HttpClient> httpClientCaptor = ArgumentCaptor.forClass(HttpClient.class);
-
-        Mockito.verify(grant).authorizeAsync(httpClientCaptor.capture(), Mockito.eq(browser));
-        Assertions.assertEquals(executor, httpClientCaptor.getValue().executor().get());
-    }
-
     @Test
     @DisplayName("authorizeAsync(...) returns failed future on error during requestAuthCode(...)")
     @SuppressWarnings("unchecked")
     public void testAuthorizeAsyncWithError1() throws IOException {
         Consumer<URI> browser = Mockito.mock(Consumer.class);
+        var httpClient = HttpClient.newBuilder().executor(Runnable::run).build();
         var grant = Mockito.spy(new AuthorizationCodeGrant(client, authEndpoint, pkce));
         Mockito.doThrow(new IOException("error")).when(grant).requestAuthCode(Mockito.any());
 
-        var result = grant.authorizeAsync(Runnable::run, browser);
+
+        var result = grant.authorizeAsync(httpClient, browser);
 
         Assertions.assertTrue(result.isCompletedExceptionally());
     }
@@ -375,12 +361,12 @@ public class AuthorizationCodeGrantTest {
     @SuppressWarnings("unchecked")
     public void testAuthorizeAsyncWithError2() throws IOException {
         Consumer<URI> browser = Mockito.mock(Consumer.class);
-        //var executor = Mockito.mock(Executor.class);
+        var httpClient = HttpClient.newBuilder().executor(Runnable::run).build();
         var grant = Mockito.spy(new AuthorizationCodeGrant(client, authEndpoint, pkce));
         var grantWithCode = Mockito.mock(AuthorizationCodeGrant.WithAuthorizationCode.class);
         Mockito.doReturn(grantWithCode).when(grant).requestAuthCode(Mockito.any());
 
-        var result = grant.authorizeAsync(Runnable::run, browser);
+        var result = grant.authorizeAsync(httpClient, browser);
 
         Assertions.assertTrue(result.isCompletedExceptionally());
     }

--- a/src/test/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrantTest.java
+++ b/src/test/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrantTest.java
@@ -3,11 +3,16 @@ package io.github.coffeelibs.tinyoauth2client;
 import io.github.coffeelibs.tinyoauth2client.http.RedirectTarget;
 import io.github.coffeelibs.tinyoauth2client.http.response.Response;
 import io.github.coffeelibs.tinyoauth2client.util.URIUtil;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -22,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 

--- a/src/test/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrantTest.java
+++ b/src/test/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrantTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.internal.stubbing.answers.AnswersWithDelay;
 
 import java.io.IOException;
 import java.net.URI;
@@ -328,6 +329,7 @@ public class AuthorizationCodeGrantTest {
     }
 
     @Test
+    @Timeout(3)
     @DisplayName("authorizeAsync(httpClient,...) runs requestAuthCode() and getAccessToken()")
     @SuppressWarnings("unchecked")
     public void testAuthorizeAsync() throws IOException, ExecutionException, InterruptedException {
@@ -337,8 +339,8 @@ public class AuthorizationCodeGrantTest {
         var grant = Mockito.spy(new AuthorizationCodeGrant(client, authEndpoint, pkce));
         var grantWithCode = Mockito.mock(AuthorizationCodeGrant.WithAuthorizationCode.class);
         var httpResponse = Mockito.mock(HttpResponse.class);
-        Mockito.doReturn(grantWithCode).when(grant).requestAuthCode(Mockito.any());
-        Mockito.doReturn(CompletableFuture.completedFuture(httpResponse)).when(grantWithCode).getAccessTokenAsync((HttpClient) Mockito.any());
+        Mockito.doAnswer(new AnswersWithDelay(1000, invocation -> grantWithCode)).when(grant).requestAuthCode(Mockito.any());
+        Mockito.doReturn(CompletableFuture.completedFuture(httpResponse)).when(grantWithCode).getAccessTokenAsync(Mockito.any());
 
         var result = grant.authorizeAsync(httpClient, browser);
 

--- a/src/test/java/io/github/coffeelibs/tinyoauth2client/http/RedirectTargetTest.java
+++ b/src/test/java/io/github/coffeelibs/tinyoauth2client/http/RedirectTargetTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-@Timeout(value = 3)
+@Timeout(5)
 @SuppressWarnings("resource")
 public class RedirectTargetTest {
 


### PR DESCRIPTION
This removes two public methods from the `AuthorizationCodeGrant` (which is still `@ApiStatus.Experimental`). Both are merely convenience methods and can easily be replaced:

https://github.com/coffeelibs/tiny-oauth2-client/blob/e264795d5cc2acfbc85fb3bc065c7ee4a8d72583/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java#L131-L133

and

https://github.com/coffeelibs/tiny-oauth2-client/blob/e264795d5cc2acfbc85fb3bc065c7ee4a8d72583/src/main/java/io/github/coffeelibs/tinyoauth2client/AuthorizationCodeGrant.java#L175-L177

The new paradigm for the library consumer is to always pass an HttpClient instance.